### PR TITLE
Toy helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+// Sync object
+/** @type {import('@jest/types').Config.InitialOptions} */
+
+const config = {
+  verbose: true,
+  rootDir: 'src/test',
+  transform: {
+    '\\.jsx?$': 'babel-jest'
+  },
+  transformIgnorePatterns: ['<rootDir>/node_modules/']
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "babel-jest": "^27.5.1"
   }
 }

--- a/src/helpers/toyHelpers.js
+++ b/src/helpers/toyHelpers.js
@@ -1,0 +1,9 @@
+export const sortToys = (toys, direction = 'forward') => {
+  const sortedToys = toys.sort((toyA, toyB) => toyA.name.localeCompare(toyB.name));
+  return direction === "backward" ? sortedToys.reverse() : sortedToys;
+};
+
+export const filterReview = (toys, filter = 'off') => {
+  if (filter === "on") return toys.filter((toy) => toy.reviews.length > 0);
+  return toys;
+};

--- a/src/test/fixtures/toys.js
+++ b/src/test/fixtures/toys.js
@@ -1,0 +1,21 @@
+export const toys = [{
+  id: 1,
+  name: 'Sample Toy #1',
+  image_url: 'https://m.media-amazon.com/images/I/61DWaMHr8HL._AC_SX425_.jpg")\n',
+  description: 'Sample Toy #1 description',
+  reviews: [{
+    id: 1001,
+    content: 'Review content!',
+    rating: '5',
+    title: 'Review title!'
+  }]
+},{
+  id: 2,
+  name: 'Sample Toy #2 without a review',
+  image_url: 'https://i.pinimg.com/736x/b1/6a/4c/b16a4c2402353d19fd7c17847848f533--diy-dog-toys-pet-toys.jpg',
+  description: 'Sample Toy #2 description',
+  reviews: []
+}];
+
+export const toyWithReview = toys.find(toy => toy.id === 1);
+export const toyWithoutReview = toys.find(toy => toy.id === 2);

--- a/src/test/fixtures/toys.js
+++ b/src/test/fixtures/toys.js
@@ -1,7 +1,7 @@
 export const toys = [{
   id: 1,
   name: 'Sample Toy #1',
-  image_url: 'https://m.media-amazon.com/images/I/61DWaMHr8HL._AC_SX425_.jpg")\n',
+  image_url: 'https://m.media-amazon.com/images/I/61DWaMHr8HL._AC_SX425_.jpg")',
   description: 'Sample Toy #1 description',
   reviews: [{
     id: 1001,

--- a/src/test/fixtures/toys.js
+++ b/src/test/fixtures/toys.js
@@ -1,7 +1,7 @@
 export const toys = [{
   id: 1,
   name: 'Sample Toy #1',
-  image_url: 'https://m.media-amazon.com/images/I/61DWaMHr8HL._AC_SX425_.jpg")',
+  image_url: 'https://m.media-amazon.com/images/I/61DWaMHr8HL._AC_SX425_.jpg',
   description: 'Sample Toy #1 description',
   reviews: [{
     id: 1001,

--- a/src/test/unit/helpers/toyHelpers.test.js
+++ b/src/test/unit/helpers/toyHelpers.test.js
@@ -15,7 +15,7 @@ describe('toyHelpers', () => {
       const direction = 'backward';
       
       it('sorts properly', () => {
-        expect(sortToys(toys,direction)[0]).toEqual(toyWithoutReview);
+        expect(sortToys(toys, direction)[0]).toEqual(toyWithoutReview);
       });
     });
   });

--- a/src/test/unit/helpers/toyHelpers.test.js
+++ b/src/test/unit/helpers/toyHelpers.test.js
@@ -1,0 +1,42 @@
+import { sortToys, filterReview } from '../../../helpers/toyHelpers';
+import { toys, toyWithReview, toyWithoutReview } from '../../fixtures/toys';
+
+describe('toyHelpers', () => {
+  describe('sortToys', () => {
+    describe('in forward direction', () => {
+      const direction = 'forward';
+      
+      it('sorts properly', () => {
+        expect(sortToys(toys, direction)[0]).toEqual(toyWithReview);
+      });
+    });
+    
+    describe('in backward direction', () => {
+      const direction = 'backward';
+      
+      it('sorts properly', () => {
+        expect(sortToys(toys,direction)[0]).toEqual(toyWithoutReview);
+      });
+    });
+  });
+  
+  describe('filterReview', () => {
+    describe('when filter is off', () => {
+      const filter = 'off';
+
+      it('filters properly', () => {
+        expect(filterReview(toys, filter)).toEqual(toys);
+      });
+    });
+    
+    describe('when filter is on', () => {
+      const filter = 'on';
+      
+      it('filters properly', () => {
+        expect(filterReview(toys, filter)).toEqual([toyWithReview]);
+      });
+    });
+    
+    
+  });
+});


### PR DESCRIPTION
- Create a couple helpers for dealing with toys
- Sets up env so tests run
- Add sample toy data
- Test helpers

FYI, you can run the tests using `jest`.  Looks like these aren't working using `npm test`.

```
$ jest

 PASS  src/test/unit/helpers/toyHelpers.test.js
  toyHelpers
    sortToys
      in forward direction
        ✓ sorts properly (14 ms)
      in backward direction
        ✓ sorts properly (1 ms)
    filterReview
      when filter is off
        ✓ filters properly
      when filter is on
        ✓ filters properly (1 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.564 s, estimated 1 s
Ran all test suites.
```