### PR TITLE
Small tweaks to ToyForm

### DIFF
--- a/src/components/ToyForm.js
+++ b/src/components/ToyForm.js
@@ -3,13 +3,15 @@ import { Form, Button, Container } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { createToy } from '../actions/createToy';
 
-const ToyForm = ({ toy }) => {
+const ToyForm = () => {
   const dispatch = useDispatch();
-  const [form, setForm] = useState({
+  const initialFormState = {
     name: '',
     description: '',
     image_url: '',
-  });
+  };
+
+  const [form, setForm] = useState(initialFormState);
 
   const handleChange = (event) => {
     setForm({
@@ -20,12 +22,8 @@ const ToyForm = ({ toy }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    dispatch(createToy(form, toy));
-    setForm({
-      name: '',
-      description: '',
-      image_url: '',
-    });
+    dispatch(createToy(form));
+    setForm(initialFormState);
   };
 
   const { name, description, image_url } = form;

--- a/src/containers/ToysContainer.js
+++ b/src/containers/ToysContainer.js
@@ -21,7 +21,7 @@ const ToysContainer = () => {
       <Switch>
         <Route
           path="/toys/new"
-          render={(routeProps) => <ToyForm {...routeProps} toys={toys} />}
+          render={() => <ToyForm />}
         />
         <Route
           path="/toys/:id"


### PR DESCRIPTION
Just added a couple small tweaks:

1. DRYing up the form initial state
2. removing second argument sent to `createToy` (it only accepts a single argument-- it's not needed)
3. Remove props from ToyForm, you don't need any props here