### PR TITLE
Fix toyReducer.test.js

### DIFF
--- a/src/test/unit/reducers/toyReducer.test.js
+++ b/src/test/unit/reducers/toyReducer.test.js
@@ -3,15 +3,15 @@ import { toyWithReview } from '../../fixtures/toys';
 
 describe('toyReducer', () => {
   let state;
-  
-  beforeEach(() => { 
+
+  beforeEach(() => {
     state = initialState;
   });
-  
+
   it('should handle initial state', () => {
     expect(toyReducer(undefined, {})).toEqual(initialState);
   });
-  
+
   it('should handle FETCH_TOYS', () => {
     const payload = 'any-payload';
     const action = { type: 'FETCH_TOYS', payload };
@@ -24,34 +24,34 @@ describe('toyReducer', () => {
     const payload = 'any-payload';
     const action = { type: 'CREATE_TOY', payload};
     const expected = { toys: [payload] };
-    
+
     expect(toyReducer(state, action)).toEqual(expected);
   });
 
   it('should handle CREATE_REVIEW', () => {
     state = { toys: [{ ...toyWithReview, reviews: [] }] };
-    
+
     const payload = toyWithReview;
     const action = { type: 'CREATE_REVIEW', payload};
     const expected = { toys: [toyWithReview] };
-    
+
     expect(toyReducer(state, action)).toEqual(expected);
   });
 
   it('should handle DELETE_REVIEW', () => {
     state = { toys: [toyWithReview] };
-    
+
     const payload = { ...toyWithReview, reviews: [] }
     const action = { type: 'DELETE_REVIEW', payload };
     const expected = { toys: [{ ...toyWithReview, reviews: [] }]};
-    
+
     expect(toyReducer(state, action)).toEqual(expected);
   });
 
   it('should handle DELETE_TOY', () => {
     state = { toys: [toyWithReview] };
 
-    const payload = '1';
+    const payload = 1;
     const action = { type: 'DELETE_TOY', payload };
     const expected = initialState;
 


### PR DESCRIPTION
Tweaked so it expects toy id to be a number (instead of a string).

```
$ jest toyreducer
 PASS  src/test/unit/reducers/toyReducer.test.js
  toyReducer
    ✓ should handle initial state (2 ms)
    ✓ should handle FETCH_TOYS
    ✓ should handle CREATE_TOY (1 ms)
    ✓ should handle CREATE_REVIEW (1 ms)
    ✓ should handle DELETE_REVIEW
    ✓ should handle DELETE_TOY (1 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.567 s, estimated 1 s
Ran all test suites matching /toyreducer/i.
```